### PR TITLE
Make footer copyright year dynamic

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,8 @@
 ---
 import siteConfig from '~/site.config'
 import SocialLinks from '~/components/SocialLinks.astro'
+
+const currentYear = new Date().getFullYear()
 ---
 
 <footer
@@ -9,7 +11,7 @@ import SocialLinks from '~/components/SocialLinks.astro'
   {siteConfig.socialLinks && <SocialLinks socialLinks={siteConfig.socialLinks} />}
   <div class="flex flex-col md:flex-row flex-wrap flex-1 items-center justify-center">
     <span class="my-1">
-      {siteConfig.author} © 2025
+      {siteConfig.author} © {currentYear}
     </span>
     <span class="mx-5 hidden md:block"> :: </span>
     <span class="my-1">


### PR DESCRIPTION
### Motivation
- Replace the hardcoded `2025` copyright year in the footer with a runtime value so the year updates automatically.

### Description
- Added `const currentYear = new Date().getFullYear()` to `src/components/Footer.astro` frontmatter and replaced the hardcoded `2025` with `{currentYear}`.

### Testing
- Ran `npm run build` (build progressed through Astro compilation but image processing failed due to missing `sharp`), started a local dev server with `npm run dev -- --host 0.0.0.0 --port 4321` and verified the footer renders the current year via a Playwright screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699a2de529988327b4fa66a46d2fde3e)