### PR TITLE
Use provided hacker-style CR favicon SVG

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,9 +1,41 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 128 128">
-    <path d="M50.4 78.5a75.1 75.1 0 0 0-28.5 6.9l24.2-65.7c.7-2 1.9-3.2 3.4-3.2h29c1.5 0 2.7 1.2 3.4 3.2l24.2 65.7s-11.6-7-28.5-7L67 45.5c-.4-1.7-1.6-2.8-2.9-2.8-1.3 0-2.5 1.1-2.9 2.7L50.4 78.5Zm-1.1 28.2Zm-4.2-20.2c-2 6.6-.6 15.8 4.2 20.2a17.5 17.5 0 0 1 .2-.7 5.5 5.5 0 0 1 5.7-4.5c2.8.1 4.3 1.5 4.7 4.7.2 1.1.2 2.3.2 3.5v.4c0 2.7.7 5.2 2.2 7.4a13 13 0 0 0 5.7 4.9v-.3l-.2-.3c-1.8-5.6-.5-9.5 4.4-12.8l1.5-1a73 73 0 0 0 3.2-2.2 16 16 0 0 0 6.8-11.4c.3-2 .1-4-.6-6l-.8.6-1.6 1a37 37 0 0 1-22.4 2.7c-5-.7-9.7-2-13.2-6.2Z" />
-    <style>
-        path { fill: #000; }
-        @media (prefers-color-scheme: dark) {
-            path { fill: #FFF; }
-        }
-    </style>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <defs>
+    <filter id="g" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="0.8" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <radialGradient id="bg" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#0a1a0a"/>
+      <stop offset="100%" stop-color="#020802"/>
+    </radialGradient>
+    <linearGradient id="lg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#00ff46"/>
+      <stop offset="100%" stop-color="#007a20"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="32" height="32" fill="url(#bg)" rx="4"/>
+
+  <g stroke="#00ff46" stroke-width="1" fill="none" opacity="0.6">
+    <path d="M 2 6 L 2 2 L 6 2"/>
+    <path d="M 26 2 L 30 2 L 30 6"/>
+    <path d="M 30 26 L 30 30 L 26 30"/>
+    <path d="M 6 30 L 2 30 L 2 26"/>
+  </g>
+
+  <path d="M 13.5 6 C 7 6 4 9.5 4 16 C 4 22.5 7 26 13.5 26 L 14.5 23.5 C 9 23.5 6.5 21 6.5 16 C 6.5 11 9 8.5 14.5 8.5 Z" fill="url(#lg)" filter="url(#g)"/>
+
+  <rect x="7" y="5.5" width="8" height="3" rx="0.5" fill="#00cc3a" filter="url(#g)"/>
+  <rect x="7" y="23.5" width="8" height="3" rx="0.5" fill="#00cc3a" filter="url(#g)"/>
+
+  <rect x="17" y="5.5" width="3" height="21" rx="0.5" fill="url(#lg)" filter="url(#g)"/>
+
+  <path d="M 19 5.5 L 24.5 5.5 C 28 5.5 29 8 29 11 C 29 14 28 16.5 24.5 16.5 L 19 16.5 Z" fill="url(#lg)" filter="url(#g)"/>
+  <path d="M 20 8 L 24 8 C 26.5 8 27 9.5 27 11 C 27 12.5 26.5 14 24 14 L 20 14 Z" fill="url(#bg)"/>
+
+  <path d="M 20.5 15.5 L 25 16.5 L 29 26.5 L 26 26.5 L 22.5 17.5 L 20.5 17.5 Z" fill="url(#lg)" filter="url(#g)"/>
+
+  <rect x="17" y="5.5" width="10" height="3" rx="0.5" fill="#00cc3a" filter="url(#g)"/>
+
+  <circle cx="16" cy="16" r="1" fill="#00ff46" filter="url(#g)" opacity="0.8"/>
 </svg>


### PR DESCRIPTION
### Motivation
- Replace the previous favicon with the exact user-provided hacker-style CR monogram SVG to match review feedback and improve small-size legibility.
- Ensure the icon conveys a neon/terminal aesthetic with glow and high-contrast elements for both light/dark contexts.

### Description
- Replaced `public/favicon.svg` with the supplied 32x32 SVG which includes a radial background gradient, neon linear gradient fills, and a glow filter (`id="g"`).
- Preserved visual accents from the provided artwork including corner brackets, C and R letterforms, top/bottom bars, R leg, and center dot elements.
- Set the SVG `viewBox` and explicit `width`/`height` to `32` for compact favicon sizing and added rounded background `rect` with `rx="4"`.
- Applied compact path/rect/circle elements and gradient references (`url(#bg)`, `url(#lg)`) to match the supplied asset exactly.

### Testing
- Served the `public/` directory with `python3 -m http.server 4173 --bind 0.0.0.0` and verified the SVG served successfully.
- Captured a visual verification screenshot using Playwright, saved as `artifacts/favicon-user-provided-hacker-cr.png`, and the rendering inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699a2dbff2bc8327b58a2bddcbc5bd22)