### PR TITLE
Add here.now publish to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,40 @@ jobs:
       - name: Build site
         run: npm run build
 
+      - name: Install here.now skill
+        if: ${{ secrets.HERENOW_API_KEY != '' }}
+        run: npx skills add heredotnow/skill --skill here-now -g -y
+
+      - name: Publish to here.now
+        if: ${{ secrets.HERENOW_API_KEY != '' }}
+        id: herenow
+        env:
+          HERENOW_API_KEY: ${{ secrets.HERENOW_API_KEY }}
+        run: |
+          mkdir -p ~/.herenow
+          printf "%s" "$HERENOW_API_KEY" > ~/.herenow/credentials
+          chmod 600 ~/.herenow/credentials
+
+          OUT=$("$HOME/.agents/skills/here-now/scripts/publish.sh" ./dist --client github-actions)
+          echo "$OUT"
+
+          SITE_URL=$(echo "$OUT" | grep 'publish_result.site_url=' | cut -d= -f2)
+          SLUG=$(echo "$SITE_URL" | sed -E 's#https://([^.]+)\.here\.now/.*#\1#')
+
+          echo "site_url=$SITE_URL" >> "$GITHUB_OUTPUT"
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+
+      - name: Point cr.here.now to latest slug
+        if: ${{ secrets.HERENOW_API_KEY != '' }}
+        env:
+          HERENOW_API_KEY: ${{ secrets.HERENOW_API_KEY }}
+          HERENOW_SLUG: ${{ steps.herenow.outputs.slug }}
+        run: |
+          curl -sS -X PATCH "https://here.now/api/v1/links/__root__" \
+            -H "Authorization: Bearer $HERENOW_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"slug\":\"$HERENOW_SLUG\"}"
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary
- keep existing GitHub Pages deploy
- add here.now publish in CI using `HERENOW_API_KEY`
- relink `cr.here.now` root to latest slug on each main deploy

## Notes
- here.now steps run only when `HERENOW_API_KEY` secret is present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI/CD deployment pipeline and introduces an external publish + link-update step that depends on secrets and output parsing, which could affect deploy reliability if misconfigured.
> 
> **Overview**
> The deploy GitHub Action now optionally publishes the built `./dist` site to **here.now** when `HERENOW_API_KEY` is present, capturing the returned `site_url`/slug as step outputs.
> 
> It then PATCHes the here.now `__root__` link to point `cr.here.now` at the latest published slug, while leaving the existing GitHub Pages deployment flow intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee368ccadc28825d72fd50b2e97bd1009e9397b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->